### PR TITLE
Remove travis_wait to travis.yml to fix error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,3 @@ node_js:
 cache:
   directories:
     - "node_modules"
-install: travis_wait 30 mvn install


### PR DESCRIPTION
### Summary

This is to remove the travis_wait property from the travis.yml file