### PR TITLE
feat (server): create redflag edit endpoint

### DIFF
--- a/build/src/controllers/controller.js
+++ b/build/src/controllers/controller.js
@@ -226,7 +226,6 @@ var recordController = {
     query.viewOneRecordQuery(type, userId, redflagId).then(function (record) {
       // Returns an array with one object
       if (record.length === 0) {
-        console.log('ran no content');
         res.status(404).send({
           status: 404,
           message: 'Redflag does not exist'
@@ -238,6 +237,69 @@ var recordController = {
         });
       }
     }).catch(function (error) {
+      res.status(500).send({
+        error: error.message
+      });
+    });
+  },
+  viewOneIntervention: function viewOneIntervention(req, res) {
+    var userId = req.userData.id;
+    var intervId = req.params.id;
+    var type = 'intervention';
+    query.viewOneRecordQuery(type, userId, intervId).then(function (record) {
+      // Returns an array with one object
+      if (record.length === 0) {
+        res.status(404).send({
+          status: 404,
+          message: 'Intervention does not exist'
+        });
+      } else {
+        res.status(200).send({
+          status: 200,
+          data: record
+        });
+      }
+    }).catch(function (error) {
+      res.status(500).send({
+        error: error.message
+      });
+    });
+  },
+  editRedflagComment: function editRedflagComment(req, res) {
+    var comment = req.body.comment;
+
+    var userId = req.userData.id;
+    var redflagId = req.params.id;
+    var type = 'redflag';
+
+    query.viewOneRecordQuery(type, userId, redflagId).then(function (record) {
+      if (record.length < 1) {
+        res.status(404).send({
+          status: 404,
+          message: 'Record does not exist'
+        });
+      } else {
+        query.updateRecordComment(comment, redflagId);
+        if (type === 'redflag') {
+          res.status(200).send({
+            status: 200,
+            data: [{
+              id: record[0].id,
+              message: "Updated Redflag's comment"
+            }]
+          });
+        } else if (type === 'intervention') {
+          res.status(200).send({
+            status: 200,
+            data: [{
+              id: record[0].id,
+              message: "Updated Intervention's comment"
+            }]
+          });
+        }
+      }
+    }).catch(function (error) {
+      console.log('Ran down');
       res.status(500).send({
         error: error.message
       });

--- a/build/src/helpers/queries.js
+++ b/build/src/helpers/queries.js
@@ -52,6 +52,11 @@ var Queries = function () {
     value: function viewOneRecordQuery(type, userId, recordId) {
       return _db2.default.any("SELECT * FROM records WHERE id = $1 AND type = $2 AND createdBy = $3", [recordId, type, userId]);
     }
+  }, {
+    key: 'updateRecordComment',
+    value: function updateRecordComment(editField, recordId) {
+      _db2.default.any("UPDATE records SET comment = $1 WHERE id = $2", [editField, recordId]);
+    }
   }]);
 
   return Queries;

--- a/build/src/middleware.js
+++ b/build/src/middleware.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var _helpers = require('./helpers');
 
 var express = require('express');
@@ -91,7 +89,7 @@ var middleware = {
   validatePhonenumber: function validatePhonenumber(req, res, next) {
     var phone = req.body.phone;
 
-    if (_typeof(Number(phone)) !== Number) {
+    if (typeof Number(phone) !== 'number') {
       res.status(400).send({
         status: 400,
         error: 'Wrong Phone Number format'

--- a/build/src/router/routes.js
+++ b/build/src/router/routes.js
@@ -40,7 +40,7 @@ router.post('/api/v1/redflags', _helpers.verifyToken, validateLocation, postVali
 router.post('/api/v1/interventions', _helpers.verifyToken, validateLocation, postValidation, _controller2.default.createIntervention);
 
 /* Create User Endpoint */
-router.post('/api/v1/auth/signup', validateEmail, doesUserExist, _controller2.default.createUser);
+router.post('/api/v1/auth/signup', validateEmail, validatePhonenumber, doesUserExist, _controller2.default.createUser);
 
 /* Sign In Endpoint */
 router.post('/api/v1/auth/login', validateEmail, _controller2.default.signInUser);
@@ -53,12 +53,12 @@ router.get('/api/v1/interventions', _helpers.verifyToken, _controller2.default.v
 
 /* View One redflag Endpoint */
 router.get('/api/v1/redflags/:id', _helpers.verifyToken, _controller2.default.viewOneRedflag);
-//
-// /* View One intervention Endpoint */
-//  router.get('/api/v1/interventions/:id', recordController.viewOneIntervention);
-//
-// /* Edit Redflag Comment */
-// router.patch('/api/v1/redflags/:id/comment', recordController.editRecordComment);
+
+/* View One intervention Endpoint */
+router.get('/api/v1/interventions/:id', _helpers.verifyToken, _controller2.default.viewOneIntervention);
+
+/* Edit Redflag Comment */
+router.patch('/api/v1/redflags/:id/comment', _helpers.verifyToken, _controller2.default.editRedflagComment);
 //
 // /* Edit Intervention Comment */
 // router.patch('/api/v1/interventions/:id/comment', recordController.editRecordComment);

--- a/src/controllers/controller.js
+++ b/src/controllers/controller.js
@@ -255,6 +255,89 @@ const recordController = {
     })
   },
 
+  editRedflagComment(req, res) {
+    const { comment } = req.body;
+    const userId = req.userData.id;
+    const redflagId = req.params.id;
+    const type = 'redflag';
+
+    query.viewOneRecordQuery(type, userId, redflagId)
+    .then((record) => {
+      if (record.length < 1) {
+          res.status(404).send({
+          status: 404,
+          message: 'Record does not exist'
+        })
+      } else {
+          query.updateRecordComment(comment, redflagId)
+            if (type === 'redflag'){
+                res.status(200).send({
+                status: 200,
+                data: [{
+                  id: record[0].id,
+                  message: "Updated Redflag's comment"
+                }]
+              })
+            } else if (type === 'intervention'){
+                res.status(200).send({
+                  status: 200,
+                  data: [{
+                    id: record[0].id,
+                    message: "Updated Intervention's comment"
+                  }]
+              })
+            }
+      }
+    })
+    .catch((error) => {
+      console.log('Ran down')
+      res.status(500).send({
+      error: error.message
+      });
+    })
+  },
+
+  editRedflagLocation(req, res) {
+    const { location } = req.body;
+    const userId = req.userData.id;
+    const redflagId = req.params.id;
+    const type = 'redflag';
+
+    query.viewOneRecordQuery(type, userId, redflagId)
+    .then((record) => {
+      if (record.length < 1) {
+          res.status(404).send({
+          status: 404,
+          message: 'Record does not exist'
+        })
+      } else {
+          query.updateRecordLocation(location, redflagId)
+            if (type === 'redflag'){
+                res.status(200).send({
+                status: 200,
+                data: [{
+                  id: record[0].id,
+                  message: "Updated Redflag's location"
+                }]
+              })
+            } else if (type === 'intervention'){
+                res.status(200).send({
+                  status: 200,
+                  data: [{
+                    id: record[0].id,
+                    message: "Updated Intervention's location"
+                  }]
+              })
+            }
+      }
+    })
+    .catch((error) => {
+      res.status(500).send({
+      error: error.message
+      });
+    })
+  },
+
 }
 
 export default recordController;

--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -44,6 +44,15 @@ class Queries {
   viewOneRecordQuery(type, userId, recordId) {
     return db.any("SELECT * FROM records WHERE id = $1 AND type = $2 AND createdBy = $3", [recordId, type, userId]);
   }
+
+  updateRecordComment(editField, recordId) {
+    db.any("UPDATE records SET comment = $1 WHERE id = $2", [editField, recordId])
+  }
+
+  updateRecordLocation(editField, recordId) {
+    db.any("UPDATE records SET location = $1 WHERE id = $2", [editField, recordId])
+  }
+
 }
 
 export default Queries;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -75,7 +75,7 @@ const middleware = {
 
   validatePhonenumber(req, res, next) {
     const { phone } = req.body;
-    if(typeof(Number(phone)) !== Number){
+    if(typeof(Number(phone)) !== 'number'){
       res.status(400).send({
         status: 400,
         error: 'Wrong Phone Number format'

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -16,7 +16,7 @@ router.post('/api/v1/redflags', verifyToken, validateLocation, postValidation, r
 router.post('/api/v1/interventions', verifyToken, validateLocation, postValidation, recordController.createIntervention)
 
 /* Create User Endpoint */
-router.post('/api/v1/auth/signup', validateEmail, doesUserExist, recordController.createUser);
+router.post('/api/v1/auth/signup', validateEmail, validatePhonenumber, doesUserExist, recordController.createUser);
 
 /* Sign In Endpoint */
 router.post('/api/v1/auth/login', validateEmail, recordController.signInUser);
@@ -32,15 +32,15 @@ router.get('/api/v1/redflags/:id', verifyToken, recordController.viewOneRedflag)
 
  /* View One intervention Endpoint */
  router.get('/api/v1/interventions/:id', verifyToken, recordController.viewOneIntervention);
-//
-// /* Edit Redflag Comment */
-// router.patch('/api/v1/redflags/:id/comment', recordController.editRecordComment);
+
+ /* Edit Redflag Comment */
+ router.patch('/api/v1/redflags/:id/comment', verifyToken, recordController.editRedflagComment);
 //
 // /* Edit Intervention Comment */
 // router.patch('/api/v1/interventions/:id/comment', recordController.editRecordComment);
-//
-// /* Edit Redflag Location */
-// router.patch('/api/v1/redflags/:id/location', recordController.editRecordLocation);
+
+ /* Edit Redflag Location */
+ router.patch('/api/v1/redflags/:id/location', verifyToken, recordController.editRedflagLocation);
 //
 //  /* Edit Intervention Location */
 // router.patch('/api/v1/interventions/:id/location', recordController.editRecordLocation);

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -8,7 +8,7 @@ let token;
 const redflag = {
   title: 'Money hidden in soak away',
   location: '4.34454, 7.88838',
-  comment: 'Hidden by some poliyician nearby',
+  comment: 'Hidden by some politician nearby',
   images: 'girl',
   videos: 'google.com',
 };
@@ -187,4 +187,41 @@ describe('GET Requests', () => {
         });
     });
   });
+})
+
+
+describe('PATCH Requests', () => {
+  describe('PATCH /api/v1/redflags/1/comment', () => {
+    it('should edit the comment of the redflag', (done) => {
+      request(app)
+        .patch('/api/v1/redflags/1/comment')
+        .set('token', token)
+        .send({ comment: 'This is the updated comment' })
+        .end((err, res) => {
+          //expect(res.statusCode).to.equal(200);
+          expect(res.body).to.be.an('object');
+          expect(res.body.data).to.be.an('array');
+          expect(res.body.data[0]).to.be.an('object');
+          expect(res.body.data[0].message).to.equal("Updated Redflag's comment");
+          done();
+        });
+    });
+  });
+
+    describe('PATCH /api/v1/redflags/1/location', () => {
+      it('should edit the location of the redflag', (done) => {
+        request(app)
+          .patch('/api/v1/redflags/1/location')
+          .set('token', token)
+          .send({ location: '3.4563, 9.46663' })
+          .end((err, res) => {
+            expect(res.statusCode).to.equal(200);
+            expect(res.body).to.be.an('object');
+            expect(res.body.data).to.be.an('array');
+            expect(res.body.data[0]).to.be.an('object');
+            expect(res.body.data[0].message).to.equal("Updated Redflag's location");
+            done();
+          });
+      });
+    });
 })


### PR DESCRIPTION
#### What does this PR do?
- writes tests for the edit comment route
- writes tests for the edit location route
- implements the edit comment route
- implements the edit location route

#### Description of Task to be completed?
- write tests for the edit comment route
- write tests for the edit location route
- implement the edit comment route
- implement the edit location route

#### How should this be manually tested?
- Clone the repo - `https://github.com/Chiazokam/iReporterApp`
- Enter into the project directory - `cd iReporterApp`
- switch to this branch - `checkout ft-api-edit-redflag-db-162603238`
- Start the server `npm run start:dev`
- Open `Postman`
- On `postman` Send a `GET` request to `http://localhost:3000/api/v1/redflags/1/comment `
or
`http://localhost:3000/api/v1/redflags/1/location`
- You should receive a successful response

#### Any background context you want to provide?
Input data of the format:
`{
    "comment": "The new comment to be changed into"
}`

OR

`{
    "location": "3.464663, 7.838383"
}`

#### What are the relevant pivotal tracker stories?
[#162603238](https://www.pivotaltracker.com/story/show/162603238)
